### PR TITLE
Remove projects.h

### DIFF
--- a/ext/projrb.c
+++ b/ext/projrb.c
@@ -1,5 +1,4 @@
 #include <ruby.h>
-#include <projects.h>
 #include <proj_api.h>
  
 static VALUE mProjrb;


### PR DESCRIPTION
It's no longer part of the public API in proj 4.8, so the c extension doesn't build, Everything builds fine if it's removed.
